### PR TITLE
Add more graphs which show db time and quantity

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,7 @@
   text-align: center;
 }
 
-/** Sidenav/topnav */ 
+/** Sidenav/topnav */
 ul.sidenav {
   list-style-type: none;
   margin: 0;
@@ -10,12 +10,12 @@ ul.sidenav {
   padding-top: 10px;
   width: 200px;
   background-color: #555;
-  position: absolute;
+  position: fixed;
   height: 100%;
   overflow: auto;
 }
 
-ul.sidenav li{
+ul.sidenav li {
   display: block;
   color: white;
   padding: 6px 10px;
@@ -34,18 +34,20 @@ div.content {
     height: 55px;
     position: relative;
   }
-  
+
   ul.sidenav li {
     float: left;
     padding: auto;
   }
-  
-  div.content {margin-left: 0;}
+
+  div.content {
+    margin-left: 0;
+  }
 }
 
 @media screen and (max-width: 400px) {
   ul.sidenav {
-    height: auto
+    height: auto;
   }
 
   ul.sidenav li {
@@ -54,7 +56,7 @@ div.content {
   }
 }
 
-/** Dark mode toggle switch */ 
+/** Dark mode toggle switch */
 .switch {
   position: relative;
   display: inline-block;
@@ -62,7 +64,7 @@ div.content {
   height: 20px;
 }
 
-.switch input { 
+.switch input {
   opacity: 0;
   width: 0;
   height: 0;
@@ -76,8 +78,8 @@ div.content {
   right: 0;
   bottom: 0;
   background-color: #282c34;
-  -webkit-transition: .2s;
-  transition: .2s;
+  -webkit-transition: 0.2s;
+  transition: 0.2s;
 }
 
 .slider:before {
@@ -88,8 +90,8 @@ div.content {
   left: 4px;
   bottom: 4px;
   background-color: white;
-  -webkit-transition: .2s;
-  transition: .2s;
+  -webkit-transition: 0.2s;
+  transition: 0.2s;
 }
 
 input:checked + .slider {
@@ -97,7 +99,7 @@ input:checked + .slider {
 }
 
 input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
+  box-shadow: 0 0 1px #2196f3;
 }
 
 input:checked + .slider:before {
@@ -134,18 +136,20 @@ input:checked + .slider:before {
 #display-button:hover {
   background-color: #006064;
   color: white;
-  box-shadow: 0 6px 12px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.2);
+  box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.2);
 }
 
 /** Raw data */
 #rawData {
   margin-top: 10px;
   width: 90%;
+  height: 500px;
+  font-size: 12px;
   display: none;
   overflow-y: auto;
   margin-left: auto;
   margin-right: auto;
-  border-left: 5px solid #00838F;
+  border-left: 5px solid #00838f;
   background-color: #006064;
   color: white;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,10 @@
 import React from "react";
 import "./App.css";
 import LineChart from "./charts/LineChart";
+//import BarChart from "./charts/BarChart";
 import Chart from "chart.js";
 import DataService from "./common/services/DataServices";
+import ChartDataLabels from "chartjs-plugin-datalabels";
 
 /** Main application class */
 class App extends React.Component {
@@ -23,13 +25,14 @@ class App extends React.Component {
     DataService.getChartData("").then(data => {
       this.setState({ data: data });
     });
+    Chart.plugins.unregister(ChartDataLabels);
   }
 
   componentDidUpdate() {}
 
   /** Shows/hides JSON data using a button
    * Triggers on display-button click
-  */
+   */
   onShowDataClicked() {
     const x = this.showDataRef.current;
     if (x.style.display === "none") {
@@ -89,7 +92,9 @@ class App extends React.Component {
         <div className="content">
           <div className="main chart-wrapper">
             <LineChart
-              data={this.state.data.graphs}
+              datasetLabels={this.state.data.graphs.map(d => d.testStartTime)}
+              data1={this.state.data.graphs.map(d => d.reqTime)}
+              data2={this.state.data.graphs.map(d => d.backendTime)}
               chartTitle="Czas przetwarzania żądania"
               title1="Całkowity"
               title2="W kontrolerze backendu"
@@ -98,8 +103,45 @@ class App extends React.Component {
               textColor={graphTextColor}
             />
           </div>
+          <div className="main chart-wrapper">
+            <LineChart
+              datasetLabels={this.state.data.graphs.map(d => d.testStartTime)}
+              data1={this.state.data.graphs.map(d => d.dbSelectsTime)}
+              data2={this.state.data.graphs.map(d => d.dbUpdatesTime)}
+              data3={this.state.data.graphs.map(d => d.dbInsertsTime)}
+              data4={this.state.data.graphs.map(d => d.dbDeletesTime)}
+              chartTitle="Czasy przetwarzania żądania na bazie danych"
+              title1="Selects"
+              title2="Updates"
+              title3="Inserts"
+              title4="Deletes"
+              xlabel="Data"
+              ylabel="Czas trwania"
+              textColor={graphTextColor}
+            />
+          </div>
+          <div className="main chart-wrapper">
+            <LineChart
+              datasetLabels={this.state.data.graphs.map(d => d.testStartTime)}
+              data1={this.state.data.graphs.map(d => d.dbSelectsQuantity)}
+              data2={this.state.data.graphs.map(d => d.dbUpdatesQuantity)}
+              data3={this.state.data.graphs.map(d => d.dbInsertsQuantity)}
+              data4={this.state.data.graphs.map(d => d.dbDeletesQuantity)}
+              chartTitle="Ilość żądań"
+              title1="Selects"
+              title2="Updates"
+              title3="Inserts"
+              title4="Deletes"
+              xlabel="Data"
+              ylabel="Czas trwania"
+              textColor={graphTextColor}
+            />
+          </div>
+          <div>
+            <center>Ilość wpisów: {this.state.data.graphs.length}</center>
+          </div>
           <div id="rawData" ref={this.showDataRef}>
-            <span>{JSON.stringify(this.state.data)}</span>
+            <code>{JSON.stringify(this.state.data)}</code>
           </div>
         </div>
       </div>

--- a/src/charts/BarChart.jsx
+++ b/src/charts/BarChart.jsx
@@ -1,53 +1,117 @@
-import React from 'react';
-import Chart from 'chart.js';
+import React from "react";
+import Chart from "chart.js";
 
-/** Class used to show data using vertical bar chart */
+/** Graphs a chart using vertical bars
+ * Available props:
+ * - data (Datasets to plot)
+ * - chartTitle (Chart title)
+ * - title1 (1st dataset title)
+ * - title2 (2nd dataset title)
+ * - xlabel (X axis label)
+ * - ylabel (Y axis label)
+ * - textColor (Font color)
+ */
 class BarChart extends React.Component {
-    constructor(props) {
-        super(props);
-        this.canvasRef = React.createRef();
-    }
+  constructor(props) {
+    super(props);
+    this.canvasRef = React.createRef();
+    Chart.defaults.global.defaultFontColor = this.props.textColor;
+    Chart.defaults.global.defaultFontFamily = "'Roboto', sans-serif";
+  }
 
-    /** Sets up new bar Chart (using chart.js lib) on component mount*/
-    componentDidMount() {
-        this.myChart = new Chart(this.canvasRef.current, {
-            type: 'bar',
-            options: {
-                maintainAspectRatio: false,
-                scales: {
-                    yAxes: [
-                        {
-                            ticks: {
-                                min: 0,
-                                max: 100
-                            }
-                        }
-                    ]
+  /** Sets up new bar Chart (using chart.js lib) on component mount*/
+  componentDidMount() {
+    this.myBarChart = new Chart(this.canvasRef.current, {
+      type: "bar",
+      data: {
+        labels: this.props.datasetLabels,
+        datasets: [
+          {
+            label: this.props.title1,
+            backgroundColor: "#006064",
+            borderColor: "#006064",
+            data: this.props.data1
+          },
+          {
+            label: this.props.title2,
+            backgroundColor: "#640300",
+            borderColor: "#640300",
+            data: this.props.data2
+          },
+          {
+            label: this.props.title3,
+            backgroundColor: "#00BCD4",
+            borderColor: "#00BCD4",
+            data: this.props.data3
+          },
+          {
+            label: this.props.title4,
+            backgroundColor: "#8F3014",
+            borderColor: "#8F3014",
+            data: this.props.data4
+          }
+        ]
+      },
+      options: {
+        maintainAspectRatio: false,
+        responsive: true,
+        title: {
+          display: true,
+          fontSize: 20,
+          text: this.props.chartTitle,
+          fontColor: this.props.textColor
+        },
+        scales: {
+          xAxes: [
+            {
+              display: true,
+              type: "time",
+              time: {
+                unit: "second",
+                displayFormats: {
+                  second: "hh:mm:ss"
                 }
-            },
-            data: {
-                labels: this.props.data.map(d => d.label),
-                datasets: [{
-                    label: this.props.title,
-                    data: this.props.data.map(d => d.value),
-                    backgroundColor: this.props.color
-                }]
+              },
+              distribution: "series",
+              scaleLabel: {
+                display: true,
+                labelString: this.props.xlabel
+              },
+              stacked: true
             }
-        });
-    }
+          ],
+          yAxes: [
+            {
+              display: true,
+              scaleLabel: {
+                display: true,
+                labelString: this.props.ylabel
+              },
+              stacked: true
+            }
+          ]
+        }
+      }
+    });
+  }
 
-    /** Refresh data and label on every component update */
-    componentDidUpdate() {
-        this.myChart.data.labels = this.props.data.map(d => d.label);
-        this.myChart.data.datasets[0].data = this.props.data.map(d => d.value);
-        this.myChart.update();
+  /** Refresh data and label on every component update */
+  componentDidUpdate(prevProps) {
+    // TODO: https://pl.reactjs.org/docs/react-component.html#componentdidupdate
+    this.myBarChart.data.labels = this.props.datasetLabels;
+    this.myBarChart.data.datasets[0].data = this.props.data1;
+    this.myBarChart.data.datasets[1].data = this.props.data2;
+    this.myBarChart.data.datasets[2].data = this.props.data3;
+    this.myBarChart.data.datasets[3].data = this.props.data4;
+    if (this.props.textColor !== prevProps.textColor) {
+      this.myBarChart.options.title.fontColor = this.props.textColor;
     }
+    this.myBarChart.update();
+  }
 
-    render() {
-        return (
-            <canvas ref={this.canvasRef} />
-        );
-    }
+  render() {
+    return <canvas ref={this.canvasRef} />;
+  }
 }
 
 export default BarChart;

--- a/src/charts/LineChart.jsx
+++ b/src/charts/LineChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Chart from "chart.js";
-// eslint-disable-next-line
+//eslint-disable-next-line
 import ChartDataLabels from "chartjs-plugin-datalabels";
 
 /** Graphs a chart using connected points
@@ -23,24 +23,46 @@ class LineChart extends React.Component {
 
   /** Sets up new line Chart (using chart.js lib) on component mount using set props */
   componentDidMount() {
-    this.myChart = new Chart(this.canvasRef.current, {
+    this.myLineChart = new Chart(this.canvasRef.current, {
       type: "line",
       data: {
-        labels: this.props.data.map(d => d.testStartTime),
+        labels: this.props.datasetLabels,
         datasets: [
           {
             label: this.props.title1,
             backgroundColor: "#006064",
             borderColor: "#006064",
-            data: this.props.data.map(d => d.reqTime),
-            fill: false
+            data: this.props.data1,
+            fill: false,
+            steppedLine: true,
+            showLine: false
           },
           {
             label: this.props.title2,
+            backgroundColor: "#640300",
+            borderColor: "#640300",
+            data: this.props.data2,
+            fill: false,
+            steppedLine: true,
+            showLine: false
+          },
+          {
+            label: this.props.title3,
             backgroundColor: "#00BCD4",
             borderColor: "#00BCD4",
-            data: this.props.data.map(d => d.backendTime),
-            fill: false
+            data: this.props.data3,
+            fill: false,
+            steppedLine: true,
+            showLine: false
+          },
+          {
+            label: this.props.title4,
+            backgroundColor: "#8F3014",
+            borderColor: "#8F3014",
+            data: this.props.data4,
+            fill: false,
+            steppedLine: true,
+            showLine: false
           }
         ]
       },
@@ -58,13 +80,21 @@ class LineChart extends React.Component {
           intersect: true
         },
         tooltips: {
-          mode: "index",
+          mode: "nearest",
           intersect: false
         },
         scales: {
           xAxes: [
             {
               display: true,
+              type: "time",
+              time: {
+                unit: "second",
+                displayFormats: {
+                  second: "hh:mm:ss"
+                }
+              },
+              distribution: "series",
               scaleLabel: {
                 display: true,
                 labelString: this.props.xlabel
@@ -86,7 +116,7 @@ class LineChart extends React.Component {
             anchor: "center",
             font: {
               size: 8,
-              weight: "bolder"
+              weight: "bold"
             },
             backgroundColor: function(context) {
               return context.dataset.backgroundColor;
@@ -95,6 +125,16 @@ class LineChart extends React.Component {
             color: this.props.textColor,
             clamp: "true",
             display: "auto"
+          },
+          zoom: {
+            pan: {
+              enabled: true,
+              mode: "x"
+            },
+            zoom: {
+              enabled: true,
+              mode: "x"
+            }
           }
         }
       }
@@ -104,15 +144,15 @@ class LineChart extends React.Component {
   /** Refresh chart properties on every component update */
   componentDidUpdate(prevProps) {
     // TODO: https://pl.reactjs.org/docs/react-component.html#componentdidupdate
-    this.myChart.data.labels = this.props.data.map(d => d.testStartTime);
-    this.myChart.data.datasets[0].data = this.props.data.map(d => d.reqTime);
-    this.myChart.data.datasets[1].data = this.props.data.map(
-      d => d.backendTime
-    );
+    this.myLineChart.data.labels = this.props.datasetLabels;
+    this.myLineChart.data.datasets[0].data = this.props.data1;
+    this.myLineChart.data.datasets[1].data = this.props.data2;
+    this.myLineChart.data.datasets[2].data = this.props.data3;
+    this.myLineChart.data.datasets[3].data = this.props.data4;
     if (this.props.textColor !== prevProps.textColor) {
-      this.myChart.options.title.fontColor = this.props.textColor;
+      this.myLineChart.options.title.fontColor = this.props.textColor;
     }
-    this.myChart.update();
+    this.myLineChart.update();
   }
 
   render() {


### PR DESCRIPTION
Because of large amounts of data shown, datalabels have been temporarily removed for clarity purposes.

Known issues:
- first graph shows 2 "undefined" datasets
- tooltips may not work as expected (too many data points)